### PR TITLE
crawl for geom_alt prop updates

### DIFF
--- a/data/112/598/312/3/1125983123.geojson
+++ b/data/112/598/312/3/1125983123.geojson
@@ -504,6 +504,9 @@
     },
     "wof:country":"BS",
     "wof:created":1497298655,
+    "wof:geom_alt":[
+        "qs_pg"
+    ],
     "wof:geomhash":"feada09b3a132e2d6a026251722708cc",
     "wof:hierarchy":[
         {
@@ -514,7 +517,7 @@
         }
     ],
     "wof:id":1125983123,
-    "wof:lastmodified":1566629952,
+    "wof:lastmodified":1582319601,
     "wof:name":"Nassau",
     "wof:parent_id":85669063,
     "wof:placetype":"locality",

--- a/data/856/323/39/85632339.geojson
+++ b/data/856/323/39/85632339.geojson
@@ -1010,6 +1010,10 @@
     },
     "wof:country":"BS",
     "wof:country_alpha3":"BHS",
+    "wof:geom_alt":[
+        "naturalearth",
+        "naturalearth-display-terrestrial-zoom6"
+    ],
     "wof:geomhash":"25e0f8417923890e9697c316de8a7215",
     "wof:hierarchy":[
         {
@@ -1024,7 +1028,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1566629917,
+    "wof:lastmodified":1582319598,
     "wof:name":"The Bahamas",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/857/935/23/85793523.geojson
+++ b/data/857/935/23/85793523.geojson
@@ -70,6 +70,10 @@
         "qs_pg:id":423328
     },
     "wof:country":"BS",
+    "wof:geom_alt":[
+        "quattroshapes_pg",
+        "quattroshapes"
+    ],
     "wof:geomhash":"a8afce274ce69030feff302f92b3aa99",
     "wof:hierarchy":[
         {
@@ -84,7 +88,7 @@
     "wof:lang":[
         "eng"
     ],
-    "wof:lastmodified":1566629916,
+    "wof:lastmodified":1582319587,
     "wof:name":"Englerston",
     "wof:parent_id":-1,
     "wof:placetype":"neighbourhood",

--- a/data/890/434/893/890434893.geojson
+++ b/data/890/434/893/890434893.geojson
@@ -282,6 +282,9 @@
     },
     "wof:country":"BS",
     "wof:created":1469052044,
+    "wof:geom_alt":[
+        "naturalearth"
+    ],
     "wof:geomhash":"2c1d9524dc7e6ecf691fe1a5d88b723c",
     "wof:hierarchy":[
         {
@@ -292,7 +295,7 @@
         }
     ],
     "wof:id":890434893,
-    "wof:lastmodified":1566629951,
+    "wof:lastmodified":1582319601,
     "wof:name":"Freeport",
     "wof:parent_id":85669071,
     "wof:placetype":"locality",


### PR DESCRIPTION
Fixes a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/1793

This PR:

- Adds a new `wof:geom_alt` property to any "default" WOF record that has an alt file, logic [here](https://github.com/whosonfirst-data/whosonfirst-data/issues/1793#issuecomment-587895012)
- Double checks existing `src:geom_alt` properties to ensure all alt file sources are accounted for in the property list. 

This will not require PIP work to update hierarchies.