### PR TITLE
bs concordances, placetype local, and more

### DIFF
--- a/data/856/323/39/85632339.geojson
+++ b/data/856/323/39/85632339.geojson
@@ -1188,6 +1188,7 @@
         "hasc:id":"BS",
         "icao:code":"C6",
         "ioc:id":"BAH",
+        "iso:code":"BS",
         "itu:id":"BAH",
         "loc:id":"n79081362",
         "m49:code":"044",
@@ -1202,6 +1203,7 @@
         "wk:page":"The Bahamas",
         "wmo:id":"BA"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
     "wof:country_alpha3":"BHS",
     "wof:geom_alt":[
@@ -1222,7 +1224,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1694639514,
+    "wof:lastmodified":1695881169,
     "wof:name":"The Bahamas",
     "wof:parent_id":102191575,
     "wof:placetype":"country",

--- a/data/856/690/63/85669063.geojson
+++ b/data/856/690/63/85669063.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.017276,
-    "geom:area_square_m":193550542.980693,
+    "geom:area_square_m":193550793.511031,
     "geom:bbox":"-77.561879,24.987006,-77.263824,25.084052",
     "geom:latitude":25.039366,
     "geom:longitude":-77.421614,
@@ -228,10 +228,12 @@
         "gn:id":3571815,
         "gp:id":2344777,
         "hasc:id":"BS.NW",
+        "iso:code":"BS-NP",
         "qs_pg:id":493602
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"1aa43dc43936d826d548cb81b40a78e7",
+    "wof:geomhash":"745ff1ac69241bccbdb5becc90020933",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -246,7 +248,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496028,
+    "wof:lastmodified":1695884838,
     "wof:name":"New Providence",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/690/69/85669069.geojson
+++ b/data/856/690/69/85669069.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001301,
-    "geom:area_square_m":14395725.0252,
+    "geom:area_square_m":14396155.017968,
     "geom:bbox":"-78.656694,26.504853,-78.59813,26.546215",
     "geom:latitude":26.528767,
     "geom:longitude":-78.629679,
@@ -282,14 +282,16 @@
         "gn:id":3572374,
         "gp:id":2344779,
         "hasc:id":"BS.FP",
+        "iso:code":"BS-FP",
         "iso:id":"BS-FP",
         "qs_pg:id":1083802,
         "unlc:id":"BS-FP",
         "wd:id":"Q867573",
         "wk:page":"Freeport, Bahamas"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"a7f7d2fe6328da0e329cf79f3bf7e7b2",
+    "wof:geomhash":"48b261d080e7360376fdace81f3642dc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -304,7 +306,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862929,
+    "wof:lastmodified":1695884838,
     "wof:name":"City of Freeport",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/690/71/85669071.geojson
+++ b/data/856/690/71/85669071.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.052621,
-    "geom:area_square_m":581691997.77979,
+    "geom:area_square_m":581692315.105534,
     "geom:bbox":"-78.997874,26.491911,-78.411177,26.810533",
     "geom:latitude":26.620929,
     "geom:longitude":-78.627828,
@@ -250,14 +250,16 @@
         "gn:id":8030559,
         "gp:id":24551257,
         "hasc:id":"BS.WB",
+        "iso:code":"BS-WG",
         "iso:id":"BS-WG",
         "qs_pg:id":354880,
         "unlc:id":"BS-WG",
         "wd:id":"Q2702338",
         "wk:page":"West Grand Bahama"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"1cb49f602183e0ca1b6e7bf739084517",
+    "wof:geomhash":"a657894d0504f7df723210f2825cb1f1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -272,7 +274,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496028,
+    "wof:lastmodified":1695884838,
     "wof:name":"West Grand Bahama",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/690/75/85669075.geojson
+++ b/data/856/690/75/85669075.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.043999,
-    "geom:area_square_m":486173895.400452,
+    "geom:area_square_m":486173642.069832,
     "geom:bbox":"-78.474403,26.56387,-77.834625,26.776435",
     "geom:latitude":26.669986,
     "geom:longitude":-78.171123,
@@ -253,14 +253,16 @@
         "gn:id":8030546,
         "gp:id":24551245,
         "hasc:id":"BS.EB",
+        "iso:code":"BS-EG",
         "iso:id":"BS-EG",
         "qs_pg:id":985553,
         "unlc:id":"BS-EG",
         "wd:id":"Q2630334",
         "wk:page":"East Grand Bahama"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"ebc0b64b273e4e1ac5070a81312e0bf8",
+    "wof:geomhash":"09107bb94b367a4ca8581dc39c0554bc",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -275,7 +277,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862929,
+    "wof:lastmodified":1695884838,
     "wof:name":"East Grand Bahama",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/690/79/85669079.geojson
+++ b/data/856/690/79/85669079.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000118,
-    "geom:area_square_m":1292231.895848,
+    "geom:area_square_m":1292184.499284,
     "geom:bbox":"-78.340972,27.222968,-78.323638,27.236558",
     "geom:latitude":27.23058,
     "geom:longitude":-78.331855,
@@ -247,14 +247,16 @@
         "gn:id":8030547,
         "gp:id":24551246,
         "hasc:id":"BS.GC",
+        "iso:code":"BS-GC",
         "iso:id":"BS-GC",
         "qs_pg:id":230095,
         "unlc:id":"BS-GC",
         "wd:id":"Q2524373",
         "wk:page":"Grand Cay"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"c1ab72c7b18511f8899954dd54d3f10a",
+    "wof:geomhash":"fb1230fa67288c3d294d7d64a48b7b87",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -269,7 +271,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862930,
+    "wof:lastmodified":1695884326,
     "wof:name":"Grand Cay",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/690/85/85669085.geojson
+++ b/data/856/690/85/85669085.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.023004,
-    "geom:area_square_m":253767259.662956,
+    "geom:area_square_m":253766623.816673,
     "geom:bbox":"-77.962554,26.68769,-77.327952,26.928412",
     "geom:latitude":26.840755,
     "geom:longitude":-77.589943,
@@ -259,14 +259,16 @@
         "gn:id":8030551,
         "gp:id":24551249,
         "hasc:id":"BS.NA",
+        "iso:code":"BS-NO",
         "iso:id":"BS-NO",
         "qs_pg:id":212434,
         "unlc:id":"BS-NO",
         "wd:id":"Q623327",
         "wk:page":"North Abaco"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"f8939aaca7c7bf52b5e1ecc3909e285f",
+    "wof:geomhash":"d9a9ab498fb23398a8d6b208c059bb97",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -281,7 +283,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862930,
+    "wof:lastmodified":1695884838,
     "wof:name":"North Abaco",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/690/89/85669089.geojson
+++ b/data/856/690/89/85669089.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.050867,
-    "geom:area_square_m":563066634.035989,
+    "geom:area_square_m":563066014.636356,
     "geom:bbox":"-77.435455,26.285102,-77.017201,26.709133",
     "geom:latitude":26.467559,
     "geom:longitude":-77.172478,
@@ -262,14 +262,16 @@
         "gn:id":8030542,
         "gp:id":24551242,
         "hasc:id":"BS.CB",
+        "iso:code":"BS-CO",
         "iso:id":"BS-CO",
         "qs_pg:id":1086162,
         "unlc:id":"BS-CO",
         "wd:id":"Q2525371",
         "wk:page":"Central Abaco"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"c480b5da1f6394af431cd8365d8bed92",
+    "wof:geomhash":"a5cc012906e27626e3fe9a0bbd96d552",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862929,
+    "wof:lastmodified":1695884838,
     "wof:name":"Central Abaco",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/690/93/85669093.geojson
+++ b/data/856/690/93/85669093.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.047042,
-    "geom:area_square_m":522339695.153555,
+    "geom:area_square_m":522340223.307957,
     "geom:bbox":"-77.548818,25.885077,-77.01476,26.355292",
     "geom:latitude":26.104337,
     "geom:longitude":-77.227497,
@@ -256,14 +256,16 @@
         "gn:id":8030555,
         "gp:id":24551253,
         "hasc:id":"BS.SB",
+        "iso:code":"BS-SO",
         "iso:id":"BS-SO",
         "qs_pg:id":1318998,
         "unlc:id":"BS-SO",
         "wd:id":"Q2703192",
         "wk:page":"South Abaco"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"84099558a9370ac44fc559466ad1bbb5",
+    "wof:geomhash":"fd5d19ab0221475fa55ba0a7fb46067f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -278,7 +280,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862929,
+    "wof:lastmodified":1695884838,
     "wof:name":"South Abaco",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/690/97/85669097.geojson
+++ b/data/856/690/97/85669097.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001269,
-    "geom:area_square_m":14068798.899917,
+    "geom:area_square_m":14068928.173323,
     "geom:bbox":"-77.579579,26.268704,-77.537994,26.337592",
     "geom:latitude":26.306851,
     "geom:longitude":-77.561587,
@@ -253,13 +253,15 @@
         "gn:id":8030550,
         "gp:id":24551248,
         "hasc:id":"BS.MI",
+        "iso:code":"BS-MI",
         "iso:id":"BS-MI",
         "qs_pg:id":354843,
         "unlc:id":"BS-MI",
         "wd:id":"Q2702345"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"fb8adaae2fd5c088550904f01de116eb",
+    "wof:geomhash":"bc1b81e433eb0f2d80b7106ca25904c5",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -274,7 +276,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862930,
+    "wof:lastmodified":1695884838,
     "wof:name":"Moore's Island",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/03/85669103.geojson
+++ b/data/856/691/03/85669103.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002318,
-    "geom:area_square_m":25838417.050631,
+    "geom:area_square_m":25838325.291279,
     "geom:bbox":"-77.906728,25.407864,-77.819203,25.789537",
     "geom:latitude":25.660994,
     "geom:longitude":-77.85813,
@@ -272,14 +272,16 @@
         "gn:id":3571809,
         "gp:id":24551241,
         "hasc:id":"BS.BR",
+        "iso:code":"BS-BY",
         "iso:id":"BS-BY",
         "qs_pg:id":1086161,
         "unlc:id":"BS-BY",
         "wd:id":"Q827173",
         "wk:page":"Berry Islands"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"277bd327c2746101cc52da5defafa440",
+    "wof:geomhash":"af94ebf5a5cdfbb4bed31748b6992d07",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -294,7 +296,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862931,
+    "wof:lastmodified":1695884838,
     "wof:name":"Berry Islands",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/07/85669107.geojson
+++ b/data/856/691/07/85669107.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.220966,
-    "geom:area_square_m":2480355344.54723,
+    "geom:area_square_m":2480354987.724083,
     "geom:bbox":"-78.442983,24.460639,-77.736155,25.206732",
     "geom:latitude":24.796894,
     "geom:longitude":-78.084165,
@@ -253,14 +253,16 @@
         "gn:id":8030552,
         "gp:id":24551250,
         "hasc:id":"BS.NN",
+        "iso:code":"BS-NS",
         "iso:id":"BS-NS",
         "qs_pg:id":1287909,
         "unlc:id":"BS-NS",
         "wd:id":"Q2699411",
         "wk:page":"North Andros"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"2f7b49f4e727a1f09b39a96eb2322d18",
+    "wof:geomhash":"fe0507f1ef0c1c0d14c8587a19196180",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -275,7 +277,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862934,
+    "wof:lastmodified":1695884838,
     "wof:name":"North Andros",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/11/85669111.geojson
+++ b/data/856/691/11/85669111.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.110001,
-    "geom:area_square_m":1238030191.91985,
+    "geom:area_square_m":1238031305.311814,
     "geom:bbox":"-78.140859,24.152167,-77.682444,24.648993",
     "geom:latitude":24.467449,
     "geom:longitude":-77.932614,
@@ -256,14 +256,16 @@
         "gn:id":8030543,
         "gp:id":24551243,
         "hasc:id":"BS.CN",
+        "iso:code":"BS-CS",
         "iso:id":"BS-CS",
         "qs_pg:id":1086163,
         "unlc:id":"BS-CS",
         "wd:id":"Q2096558",
         "wk:page":"Central Andros"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"7f312e88960b5f8629c450218fce8162",
+    "wof:geomhash":"d5792bac0abffa1533c430593e2e5599",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -278,7 +280,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862932,
+    "wof:lastmodified":1695884838,
     "wof:name":"Central Andros",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/15/85669115.geojson
+++ b/data/856/691/15/85669115.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.039033,
-    "geom:area_square_m":440447604.295765,
+    "geom:area_square_m":440446941.55681,
     "geom:bbox":"-77.942047,23.980211,-77.631215,24.302965",
     "geom:latitude":24.139097,
     "geom:longitude":-77.782313,
@@ -256,13 +256,15 @@
         "gn:id":8030549,
         "gp:id":24551247,
         "hasc:id":"BS.MC",
+        "iso:code":"BS-MC",
         "iso:id":"BS-MC",
         "qs_pg:id":1086164,
         "unlc:id":"BS-MC",
         "wd:id":"Q2702334"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"491f8a76d93a60e095a0874939e49baf",
+    "wof:geomhash":"a44cb182f63844b6d53d5099c980a35a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -277,7 +279,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496031,
+    "wof:lastmodified":1695884838,
     "wof:name":"Mangrove Cay",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/21/85669121.geojson
+++ b/data/856/691/21/85669121.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.086071,
-    "geom:area_square_m":972663682.177282,
+    "geom:area_square_m":972664637.610435,
     "geom:bbox":"-77.834665,23.673122,-77.166656,24.221096",
     "geom:latitude":23.947483,
     "geom:longitude":-77.650691,
@@ -260,14 +260,16 @@
         "gn:id":8030556,
         "gp:id":24551254,
         "hasc:id":"BS.SN",
+        "iso:code":"BS-SA",
         "iso:id":"BS-SA",
         "qs_pg:id":230096,
         "unlc:id":"BS-SA",
         "wd:id":"Q2408672",
         "wk:page":"South Andros"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"32ba91aaa6cb1e6bb25df170ec4dbde9",
+    "wof:geomhash":"36770d0a56ad4edd071666f75e34fa78",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -282,7 +284,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862933,
+    "wof:lastmodified":1695884838,
     "wof:name":"South Andros",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/25/85669125.geojson
+++ b/data/856/691/25/85669125.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.004927,
-    "geom:area_square_m":55576017.647343,
+    "geom:area_square_m":55576064.102599,
     "geom:bbox":"-76.795074,23.974026,-76.318959,24.552965",
     "geom:latitude":24.170806,
     "geom:longitude":-76.459777,
@@ -264,13 +264,15 @@
         "gn:id":8030541,
         "gp:id":24551258,
         "hasc:id":"BS.BP",
+        "iso:code":"BS-BP",
         "iso:id":"BS-BP",
         "qs_pg:id":59888,
         "unlc:id":"BS-BP",
         "wd:id":"Q2525298"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"d80b6824404cdc744ba1ad0d99b0a94a",
+    "wof:geomhash":"3566338a1629b11cdd3639a80d14d9ec",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -285,7 +287,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496032,
+    "wof:lastmodified":1695884838,
     "wof:name":"Black Point",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/29/85669129.geojson
+++ b/data/856/691/29/85669129.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01921,
-    "geom:area_square_m":217744332.31486,
+    "geom:area_square_m":217744750.601951,
     "geom:bbox":"-76.03718,23.404853,-75.523834,23.685981",
     "geom:latitude":23.553684,
     "geom:longitude":-75.845953,
@@ -266,14 +266,16 @@
         "gn:id":3572427,
         "gp:id":2344771,
         "hasc:id":"BS.EM",
+        "iso:code":"BS-EX",
         "iso:id":"BS-EX",
         "qs_pg:id":1222225,
         "unlc:id":"BS-EX",
         "wd:id":"Q1385577",
         "wk:page":"Exuma"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"10481eb87a837cc364439f15a4144014",
+    "wof:geomhash":"8c73e3077d6c938af1840e8b0fd0ca87",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -288,7 +290,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862932,
+    "wof:lastmodified":1695884838,
     "wof:name":"Exuma",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/33/85669133.geojson
+++ b/data/856/691/33/85669133.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000703,
-    "geom:area_square_m":7841338.342286,
+    "geom:area_square_m":7841151.19447,
     "geom:bbox":"-76.872834,25.506641,-76.809364,25.532498",
     "geom:latitude":25.52104,
     "geom:longitude":-76.841268,
@@ -262,14 +262,16 @@
         "gn:id":8030558,
         "gp:id":24551256,
         "hasc:id":"BS.SW",
+        "iso:code":"BS-SW",
         "iso:id":"BS-SW",
         "qs_pg:id":59887,
         "unlc:id":"BS-SW",
         "wd:id":"Q1771681",
         "wk:page":"Spanish Wells"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"edb160104f1aab0681cc1f2b0ec84eac",
+    "wof:geomhash":"a7fecbb2289179113f89c83670c646a2",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862932,
+    "wof:lastmodified":1695884838,
     "wof:name":"Spanish Wells",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/39/85669139.geojson
+++ b/data/856/691/39/85669139.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.000307,
-    "geom:area_square_m":3424977.23826,
+    "geom:area_square_m":3425072.436209,
     "geom:bbox":"-76.787424,25.539551,-76.745895,25.551304",
     "geom:latitude":25.544885,
     "geom:longitude":-76.766142,
@@ -284,6 +284,7 @@
         "gn:id":3572238,
         "gp:id":2344776,
         "hasc:id":"BS.HB",
+        "iso:code":"BS-HI",
         "iso:id":"BS-HI",
         "nyt:id":"604318609107491951",
         "qs_pg:id":1310774,
@@ -291,8 +292,9 @@
         "wd:id":"Q2357510",
         "wk:page":"Harbour Island, Bahamas"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"2e0224dd897667e2232c61280ec914c2",
+    "wof:geomhash":"c738a2ee88603d571c1d6b748a31fb19",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -307,7 +309,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862934,
+    "wof:lastmodified":1695884838,
     "wof:name":"Harbour Island",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/45/85669145.geojson
+++ b/data/856/691/45/85669145.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.01601,
-    "geom:area_square_m":178755816.613958,
+    "geom:area_square_m":178756643.574205,
     "geom:bbox":"-76.784495,25.285283,-76.314,25.563951",
     "geom:latitude":25.442249,
     "geom:longitude":-76.617875,
@@ -263,13 +263,15 @@
         "gn:id":8030553,
         "gp:id":24551251,
         "hasc:id":"BS.NE",
+        "iso:code":"BS-NE",
         "iso:id":"BS-NE",
         "qs_pg:id":1287910,
         "unlc:id":"BS-NE",
         "wd:id":"Q2705535"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"a1a1ff77ac27992274188560474ce5b8",
+    "wof:geomhash":"1dc319a0230b6ae792a50ea142602ec9",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -284,7 +286,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862933,
+    "wof:lastmodified":1695884838,
     "wof:name":"North Eleuthera",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/47/85669147.geojson
+++ b/data/856/691/47/85669147.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.012437,
-    "geom:area_square_m":139215176.137787,
+    "geom:area_square_m":139214787.954826,
     "geom:bbox":"-76.332553,24.981391,-76.112904,25.299597",
     "geom:latitude":25.14795,
     "geom:longitude":-76.195155,
@@ -259,14 +259,16 @@
         "gn:id":8030544,
         "gp:id":24551244,
         "hasc:id":"BS.CE",
+        "iso:code":"BS-CE",
         "iso:id":"BS-CE",
         "qs_pg:id":212433,
         "unlc:id":"BS-CE",
         "wd:id":"Q938518",
         "wk:page":"Central Eleuthera"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"6bc76be7502f8330404c5441e0aada47",
+    "wof:geomhash":"5adee31e223c3ad8e7849e1438d07410",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -281,7 +283,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862935,
+    "wof:lastmodified":1695884838,
     "wof:name":"Central Eleuthera",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/51/85669151.geojson
+++ b/data/856/691/51/85669151.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.020566,
-    "geom:area_square_m":230810235.030296,
+    "geom:area_square_m":230810432.389811,
     "geom:bbox":"-76.336334,24.645006,-76.136952,24.988852",
     "geom:latitude":24.819897,
     "geom:longitude":-76.203544,
@@ -257,14 +257,16 @@
         "gn:id":8030557,
         "gp:id":24551255,
         "hasc:id":"BS.SE",
+        "iso:code":"BS-SE",
         "iso:id":"BS-SE",
         "qs_pg:id":1287913,
         "unlc:id":"BS-SE",
         "wd:id":"Q2699715",
         "wk:page":"South Eleuthera"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"1e7b14badb20526d506333d23efde90a",
+    "wof:geomhash":"688a5ac3fd92ab0860ac8da1c7c9875a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -279,7 +281,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862931,
+    "wof:lastmodified":1695884838,
     "wof:name":"South Eleuthera",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/59/85669159.geojson
+++ b/data/856/691/59/85669159.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.037913,
-    "geom:area_square_m":427043357.952488,
+    "geom:area_square_m":427042282.374237,
     "geom:bbox":"-75.757558,24.125718,-75.290435,24.70185",
     "geom:latitude":24.367336,
     "geom:longitude":-75.499803,
@@ -291,14 +291,16 @@
         "gn:id":3572678,
         "gp:id":2344770,
         "hasc:id":"BS.CI",
+        "iso:code":"BS-CI",
         "iso:id":"BS-CI",
         "qs_pg:id":1222224,
         "unlc:id":"BS-CI",
         "wd:id":"Q1050154",
         "wk:page":"Cat Island, Bahamas"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"2da8e66bbf6003a3857c8aa4399d9771",
+    "wof:geomhash":"95b66eec2f1744899cff89e82b46583d",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -313,7 +315,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862931,
+    "wof:lastmodified":1695884838,
     "wof:name":"Cat Island",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/63/85669163.geojson
+++ b/data/856/691/63/85669163.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.013906,
-    "geom:area_square_m":157027865.394724,
+    "geom:area_square_m":157027182.599996,
     "geom:bbox":"-74.558095,23.953559,-74.427113,24.143948",
     "geom:latitude":24.049919,
     "geom:longitude":-74.488238,
@@ -452,12 +452,14 @@
         "gn:id":3571493,
         "gp:id":2344789,
         "hasc:id":"BS.SS",
+        "iso:code":"BS-SS",
         "iso:id":"BS-SS",
         "qs_pg:id":1285020,
         "unlc:id":"BS-SS"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"1d63dd5b942d55e014d36ae84a406607",
+    "wof:geomhash":"682ad71c81d63e92447ee32dfa644af1",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -472,7 +474,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496031,
+    "wof:lastmodified":1695884838,
     "wof:name":"San Salvador",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/65/85669165.geojson
+++ b/data/856/691/65/85669165.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.008103,
-    "geom:area_square_m":91744842.418546,
+    "geom:area_square_m":91745150.274248,
     "geom:bbox":"-75.123647,23.650824,-74.777211,23.84691",
     "geom:latitude":23.694283,
     "geom:longitude":-74.870541,
@@ -262,13 +262,15 @@
         "gn:id":8030554,
         "gp:id":24551252,
         "hasc:id":"BS.RC",
+        "iso:code":"BS-RC",
         "iso:id":"BS-RC",
         "qs_pg:id":354863,
         "unlc:id":"BS-RC",
         "wd:id":"Q1859950"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"3d534a88fdc06efa79bc31ccd8d15ee9",
+    "wof:geomhash":"f6b8d42392126a060facae8cfd1e6479",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -283,7 +285,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862934,
+    "wof:lastmodified":1695884838,
     "wof:name":"Rum Cay",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/69/85669169.geojson
+++ b/data/856/691/69/85669169.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.040489,
-    "geom:area_square_m":460069659.56304,
+    "geom:area_square_m":460068441.489918,
     "geom:bbox":"-75.35261,22.859931,-74.832021,23.685981",
     "geom:latitude":23.226949,
     "geom:longitude":-75.077569,
@@ -280,13 +280,15 @@
         "gn:id":3572005,
         "gp:id":2344773,
         "hasc:id":"BS.LI",
+        "iso:code":"BS-LI",
         "iso:id":"BS-LI",
         "qs_pg:id":1285018,
         "wd:id":"Q890879",
         "wk:page":"Long Island, Bahamas"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"6e12a39ea69979beb42ccebb83fb0849",
+    "wof:geomhash":"108cd406209705e651ee052c01742b16",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -301,7 +303,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862931,
+    "wof:lastmodified":1695884838,
     "wof:name":"Long Island",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/75/85669175.geojson
+++ b/data/856/691/75/85669175.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.001606,
-    "geom:area_square_m":18380380.972322,
+    "geom:area_square_m":18380128.068172,
     "geom:bbox":"-75.846506,22.175035,-75.714711,22.479804",
     "geom:latitude":22.263192,
     "geom:longitude":-75.760585,
@@ -269,14 +269,16 @@
         "gn:id":3571629,
         "gp:id":2344775,
         "hasc:id":"BS.RI",
+        "iso:code":"BS-RI",
         "iso:id":"BS-RI",
         "qs_pg:id":1083800,
         "unlc:id":"BS-RI",
         "wd:id":"Q1532634",
         "wk:page":"Ragged Island, Bahamas"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"2b9ef73b2afbd1d1c49b93fcbfc565be",
+    "wof:geomhash":"8fa1a497b097ad900d85146b0f5b4d91",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -291,7 +293,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862933,
+    "wof:lastmodified":1695884838,
     "wof:name":"Ragged Island",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/77/85669177.geojson
+++ b/data/856/691/77/85669177.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.030399,
-    "geom:area_square_m":346614720.307648,
+    "geom:area_square_m":346614700.849148,
     "geom:bbox":"-74.385569,22.541449,-73.666168,23.103827",
     "geom:latitude":22.764834,
     "geom:longitude":-74.171321,
@@ -250,13 +250,15 @@
         "gn:id":8030545,
         "gp:id":24551238,
         "hasc:id":"BS.CK",
+        "iso:code":"BS-CK",
         "iso:id":"BS-CK",
         "qs_pg:id":344897,
         "unlc:id":"BS-CK",
         "wd:id":"Q1140993"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"40add0e5cccc32f244c0f5f07d0c6ecb",
+    "wof:geomhash":"7fa1e7f5ad9ab541c865c1559be0090f",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -271,7 +273,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496031,
+    "wof:lastmodified":1695884838,
     "wof:name":"Crooked Island and Long Cay",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/81/85669181.geojson
+++ b/data/856/691/81/85669181.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.044503,
-    "geom:area_square_m":508436306.090087,
+    "geom:area_square_m":508436353.055076,
     "geom:bbox":"-74.278228,22.171536,-73.468736,22.733303",
     "geom:latitude":22.491089,
     "geom:longitude":-73.971446,
@@ -281,14 +281,16 @@
         "gn:id":3572937,
         "gp:id":2344778,
         "hasc:id":"BS.AK",
+        "iso:code":"BS-AK",
         "iso:id":"BS-AK",
         "qs_pg:id":984065,
         "unlc:id":"BS-AK",
         "wd:id":"Q341919",
         "wk:page":"Acklins"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"1f77797dff3925ca744f43f0b75be4e8",
+    "wof:geomhash":"22f164d57afc54664ab38678bb6f028b",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -303,7 +305,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862933,
+    "wof:lastmodified":1695884838,
     "wof:name":"Acklins",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/85/85669185.geojson
+++ b/data/856/691/85/85669185.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.025174,
-    "geom:area_square_m":287837959.356488,
+    "geom:area_square_m":287836943.699329,
     "geom:bbox":"-73.166005,22.288235,-72.746165,22.45954",
     "geom:latitude":22.378028,
     "geom:longitude":-72.972701,
@@ -212,13 +212,15 @@
         "gn:id":3571894,
         "gp:id":2344774,
         "hasc:id":"BS.MG",
+        "iso:code":"BS-MG",
         "iso:id":"BS-MG",
         "qs_pg:id":1285019,
         "unlc:id":"BS-MG",
         "wd:id":"Q21712462"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"e24dc0e9fea8e0a1bdc86143ecf12b77",
+    "wof:geomhash":"25d20ff995643647f581500e7b4dd6aa",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -233,7 +235,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496031,
+    "wof:lastmodified":1695884838,
     "wof:name":"Mayaguana",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/89/85669189.geojson
+++ b/data/856/691/89/85669189.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.149131,
-    "geom:area_square_m":1720273064.515451,
+    "geom:area_square_m":1720273973.078382,
     "geom:bbox":"-73.703209,20.912399,-72.910438,21.561998",
     "geom:latitude":21.110911,
     "geom:longitude":-73.32093,
@@ -265,14 +265,16 @@
         "gn:id":3572154,
         "gp:id":2344772,
         "hasc:id":"BS.IN",
+        "iso:code":"BS-IN",
         "iso:id":"BS-IN",
         "qs_pg:id":318287,
         "unlc:id":"BS-IN",
         "wd:id":"Q1353668",
         "wk:page":"Inagua"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"d68f7957b0778bf36695cc036c3ce5bd",
+    "wof:geomhash":"a50229589a1a6a74b8dac9ca0dff867a",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -287,7 +289,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862932,
+    "wof:lastmodified":1695884838,
     "wof:name":"Inagua",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/97/85669197.geojson
+++ b/data/856/691/97/85669197.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.002174,
-    "geom:area_square_m":24277327.037581,
+    "geom:area_square_m":24277490.351903,
     "geom:bbox":"-80.468414,23.494045,-78.84203,26.044867",
     "geom:latitude":25.431597,
     "geom:longitude":-79.342599,
@@ -271,14 +271,16 @@
         "gn:id":3572807,
         "gp:id":2344769,
         "hasc:id":"BS.BI",
+        "iso:code":"BS-BI",
         "iso:id":"BS-BI",
         "nyt:id":"N5620075621810708471",
         "qs_pg:id":219506,
         "unlc:id":"BS-BI",
         "wd:id":"Q863476"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"6e2e4b48c2a608abf60d097cdbeb6f51",
+    "wof:geomhash":"3b73aa12ed06da956a62e4d25abacf61",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -293,7 +295,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1636496031,
+    "wof:lastmodified":1695884838,
     "wof:name":"Bimini",
     "wof:parent_id":85632339,
     "wof:placetype":"region",

--- a/data/856/691/99/85669199.geojson
+++ b/data/856/691/99/85669199.geojson
@@ -5,7 +5,7 @@
     "edtf:cessation":"uuuu",
     "edtf:inception":"uuuu",
     "geom:area":0.00038,
-    "geom:area_square_m":4203118.234764,
+    "geom:area_square_m":4203072.418148,
     "geom:bbox":"-76.9853,26.499945,-76.959828,26.554429",
     "geom:latitude":26.528059,
     "geom:longitude":-76.970455,
@@ -259,13 +259,15 @@
         "gn:id":8030548,
         "gp:id":24551240,
         "hasc:id":"BS.HT",
+        "iso:code":"BS-HT",
         "iso:id":"BS-HT",
         "qs_pg:id":344898,
         "unlc:id":"BS-HT",
         "wd:id":"Q2699709"
     },
+    "wof:concordances_official":"iso:code",
     "wof:country":"BS",
-    "wof:geomhash":"c609c7ef088a9cb32c1156ddae34a40e",
+    "wof:geomhash":"e637b54f6a876e4f5c3f3d6dfa409e15",
     "wof:hierarchy":[
         {
             "continent_id":102191575,
@@ -280,7 +282,7 @@
     "wof:lang_x_spoken":[
         "eng"
     ],
-    "wof:lastmodified":1690862934,
+    "wof:lastmodified":1695884326,
     "wof:name":"Hope Town",
     "wof:parent_id":85632339,
     "wof:placetype":"region",


### PR DESCRIPTION
Will fix a portion of https://github.com/whosonfirst-data/whosonfirst-data/issues/2164. Sets wof:concordances_official, wof:concordances_official_alt, and wof:label_*_x_preferred properties, and wof:concordances{*:*} hashes when approprirate.